### PR TITLE
Fix the binding with the new MarkerClusterer from @googlemaps/markerclusterer

### DIFF
--- a/src/components/cluster.vue
+++ b/src/components/cluster.vue
@@ -37,11 +37,7 @@ export default buildComponent({
     }
     return MarkerClusterer;
   },
-  ctrArgs: ({map, ...otherOptions}) => [{
-    map,
-    algorithm: otherOptions.algorithm,
-    renderer: otherOptions.renderer,
-  }],
+  ctrArgs: ({map, ...otherOptions}) => [{map, ...otherOptions}],
   afterCreate(inst) {
     const reinsertMarkers = () => {
       const oldMarkers = inst.getMarkers();

--- a/src/components/cluster.vue
+++ b/src/components/cluster.vue
@@ -4,72 +4,26 @@
   </div>
 </template>
 <script>
-import { MarkerClusterer } from "@googlemaps/markerclusterer";
-import buildComponent from './build-component.js'
+import {DefaultRenderer, MarkerClusterer, SuperClusterAlgorithm} from '@googlemaps/markerclusterer';
+import buildComponent from './build-component.js';
 
 const props = {
-  maxZoom: {
-    type: Number,
-    twoWay: false,
+  algorithm: {
+    type: Object,
+    default: new SuperClusterAlgorithm({}),
+    noBind: true,
   },
-  batchSizeIE: {
-    type: Number,
-    twoWay: false,
+  renderer: {
+    type: Object,
+    default: new DefaultRenderer,
+    noBind: true,
   },
-  calculator: {
-    type: Function,
-    twoWay: false,
-  },
-  enableRetinaIcons: {
-    type: Boolean,
-    twoWay: false,
-  },
-  gridSize: {
-    type: Number,
-    twoWay: false,
-  },
-  ignoreHidden: {
-    type: Boolean,
-    twoWay: false,
-  },
-  imageExtension: {
-    type: String,
-    twoWay: false,
-  },
-  imagePath: {
-    type: String,
-    twoWay: false,
-  },
-  imageSizes: {
-    type: Array,
-    twoWay: false,
-  },
-  minimumClusterSize: {
-    type: Number,
-    twoWay: false,
-  },
-  styles: {
-    type: Array,
-    twoWay: false,
-  },
-  zoomOnClick: {
-    type: Boolean,
-    twoWay: false,
-  },
-}
+};
 
 const events = [
-  'click',
-  'rightclick',
-  'dblclick',
-  'drag',
-  'dragstart',
-  'dragend',
-  'mouseup',
-  'mousedown',
-  'mouseover',
-  'mouseout',
-]
+  'clusteringbegin',
+  'clusteringend',
+];
 
 export default buildComponent({
   mappedProps: props,
@@ -79,26 +33,30 @@ export default buildComponent({
     if (typeof MarkerClusterer === 'undefined') {
       const errorMessage = 'MarkerClusterer is not installed!';
       console.error(errorMessage);
-      throw new Error(errorMessage)
+      throw new Error(errorMessage);
     }
-    return MarkerClusterer
+    return MarkerClusterer;
   },
-  ctrArgs: ({ map, ...otherOptions }) => [map, [], otherOptions],
+  ctrArgs: ({map, ...otherOptions}) => [{
+    map,
+    algorithm: otherOptions.algorithm,
+    renderer: otherOptions.renderer,
+  }],
   afterCreate(inst) {
     const reinsertMarkers = () => {
-      const oldMarkers = inst.getMarkers()
-      inst.clearMarkers()
-      inst.addMarkers(oldMarkers)
-    }
+      const oldMarkers = inst.getMarkers();
+      inst.clearMarkers();
+      inst.addMarkers(oldMarkers);
+    };
     for (let prop in props) {
       if (props[prop].twoWay) {
-        this.$on(prop.toLowerCase() + '_changed', reinsertMarkers)
+        this.$on(prop.toLowerCase() + '_changed', reinsertMarkers);
       }
     }
   },
   updated() {
     if (this.$clusterObject) {
-      this.$clusterObject.render()
+      this.$clusterObject.render();
     }
   },
   beforeUnmount() {
@@ -106,15 +64,14 @@ export default buildComponent({
     if (this.$children && this.$children.length) {
       this.$children.forEach((marker) => {
         if (marker.$clusterObject === this.$clusterObject) {
-          marker.$clusterObject = null
+          marker.$clusterObject = null;
         }
-      })
+      });
     }
-
 
     if (this.$clusterObject) {
-      this.$clusterObject.clearMarkers()
+      this.$clusterObject.clearMarkers();
     }
   },
-})
+});
 </script>


### PR DESCRIPTION
### What this PR is meant for
This PR is intended to fix the `setMaxZoom` error caused by a lack in the binding between the GMapCluster component and the constructor of the new class MarkClusterer, as discussed in issue #18. Also, it will give you the possibility to use a renderer function and clustering algorithm other than the MarkerClusterer's default ones.

### How to use the new properties 
Here is a sample with a custom renderer function and clustering algorithm (**to make it work correctly you need to install `@googlemaps/markerclusterer` in your project**):

``` vue
<template>
  <GMapMap ref="google" :center="center" :zoom="7" map-type-id="terrain" style="width: 500px; height: 300px">
    <GMapCluster
      :algorithm="algorithm"
      :renderer="{ renderer: renderer }"
    >
      <GMapMarker
        v-for="(m, index) in markers"
        :key="index"
        :clickable="true"
        :draggable="true"
        :position="m.position"
        @click="center = m.position"
      />
    </GMapCluster>
  </GMapMap>
</template>
<script>
import {GridAlgorithm} from '@googlemaps/markerclusterer';

export default {
  name: 'App',
  data() {
    return {
      algorithm: new GridAlgorithm({}),
      center: {lat: 51.093048, lng: 6.84212},
      google: null,
      markers: [
        {
          position: {
            lat: 51.093048,
            lng: 6.84212,
          },
        }, // Along list of clusters
      ],
    };
  },
  methods: {
    renderer: ({count, position}) => new this.google.maps.Marker({
      label: {
        text: String(count),
        color: 'white',
        fontSize: '10px',
      },
      position,
      // adjust zIndex to be above other markers
      zIndex: Number(this.google.maps.Marker.MAX_ZINDEX) + count,
    }),
  },
};
</script>
```

### Notes
Note that the GMapCluster component props have been removed from the `cluster.vue` file because they no longer have a bind with setter/getter methods in the MarkerClusterer, but (and this is true only for some of them) have to be passed to the chosen clustering algorithm class constructor. Thus, if you need those properties in your project, please have a look at the documentation of the available clustering algorithm classes to pass them to their constructor. [Here](https://www.npmjs.com/package/supercluster) is the documentation for the SuperClusterAlgorithm, where you can find all the parameters you may need.

A similar argument can be done for the events component binding. 

### Contribution
If you need the [onClusterClickHandler](https://googlemaps.github.io/js-markerclusterer/types/onClusterClickHandler.html) you can make a PR to add it to the GMapCluster properties to be passed to the MarkClusterer constructor following the same logic of this PR.

As a rule of thumb, before any attempt to modify the GMapCluster component to improve the binding with the MarkerClusterer class, I suggest reading its [documentation](https://googlemaps.github.io/js-markerclusterer/index.html).