### PR TITLE
Added a center instead of required on Map component.

### DIFF
--- a/src/components/map.vue
+++ b/src/components/map.vue
@@ -19,7 +19,7 @@ import { mappedPropsToVueProps } from './build-component.js'
 
 const props = {
   center: {
-    required: true,
+    default: { lat: 0, lng: 0 },
     twoWay: true,
     type: Object,
     noBind: true,


### PR DESCRIPTION
This fixes #28 . I changed the `required: true` prop for `default: { lat: 0, lng: 0 }` and it seems to work. I'm not sure why Fawmi prefered to add a required instead of default. Seems to work on my example.

@websitevirtuoso can you please just check if works fine for you as well? Seems a simple change but I don't want to break everyones project because of one line.