### PR TITLE
add support for maxZoom

### DIFF
--- a/src/components/map.vue
+++ b/src/components/map.vue
@@ -30,6 +30,12 @@ const props = {
     type: Number,
     noBind: true,
   },
+  maxZoom: {
+    required: false,
+    twoWay: true,
+    type: Number,
+    noBind: true,
+  },
   heading: {
     type: Number,
     twoWay: true,


### PR DESCRIPTION
# Details 
This PR adds support for maxZoom prop to the GMapMap component.

# Steps to Test
1. point to fork in existing project or create new project pointing to fork
2. add ':maxZoom="x"' prop to GMapMap component
3. confirm max zoom is limited to provided value
4. confirm not providing maxZoom prop does not break functionality 