### PR TITLE
Attempt to fix closeclick issue in InfoWindow

### DIFF
--- a/src/components/infoWindow.vue
+++ b/src/components/infoWindow.vue
@@ -67,14 +67,16 @@ export default buildComponent({
       this.$infoWindowObject.close()
       if (this.opened) {
         this.$infoWindowObject.open(this.$map, this.$markerObject)
-      } else {
-        this.$emit('closeclick')
       }
     },
   },
 
   afterCreate() {
     this._openInfoWindow()
+    this.$infoWindowObject.addListener('closeclick', () => {
+      this.$emit('closeclick')
+      this.$infoWindowObject.open(this.$map, this.$markerObject)
+    })
     this.$watch('opened', () => {
       this._openInfoWindow()
     })


### PR DESCRIPTION
Propagate google maps InfoWindow's closeclick event to the parent component however, re-open the InfoWindow when the event is received in order to ensure, its state is set solely by the "opened" prop of the InfoWindow component

Do not emit closeclick in the _openInfoWindow() method triggered by the watcher on the opened prop. closeclick should only be triggered, when the user atually clicked close