### PR TITLE
Add "emits" to circle and rectangle and register listener to actively…

### DIFF
--- a/src/components/circle.js
+++ b/src/components/circle.js
@@ -43,4 +43,12 @@ export default buildComponent({
   name: 'circle',
   ctr: () => google.maps.Circle,
   events,
+  emits: events,
+  afterCreate(inst) {
+    events.forEach((event) => {
+      inst.addListener(event, (payload) => {
+        this.$emit(event, payload)
+      })
+    })
+  }
 })

--- a/src/components/rectangle.js
+++ b/src/components/rectangle.js
@@ -38,4 +38,12 @@ export default buildComponent({
   name: 'rectangle',
   ctr: () => google.maps.Rectangle,
   events,
+  emits: events,
+  afterCreate(inst) {
+    events.forEach((event) => {
+      inst.addListener(event, (payload) => {
+        this.$emit(event, payload)
+      })
+    })
+  }
 })


### PR DESCRIPTION
… propagate events

As for vue3, a component can (should?) have an "emits" option containing all its emits. For some components this was implemented, but for rectangle and circle it was missing.

Further re-used the addListener code from other components to register listeners to the google maps api events and propagate them to the partent component of a circle/rectangle.