### PR TITLE
Add `noBind: true` to polyline path property

### DIFF
--- a/src/components/polyline.js
+++ b/src/components/polyline.js
@@ -14,6 +14,7 @@ const props = {
   path: {
     type: Array,
     twoWay: true,
+    noBind: true,
   },
 }
 


### PR DESCRIPTION
`noBind: true` was missing on the `path` property of the GMapPolyline component.

This was causing a bug where the `path_changed` event would stop firing after an update to the `path` value.

The polyline component has a watcher which re-wires all the events necessary to emit `path_changed`, but without noBind, the default watcher in bindProps.js also executes, completely replacing the underlying Path object with one that has no events wired.