### PR TITLE
check clusters length before render

### DIFF
--- a/src/components/cluster.vue
+++ b/src/components/cluster.vue
@@ -52,7 +52,7 @@ export default buildComponent({
     }
   },
   updated() {
-    if (this.$clusterObject) {
+    if (this.$clusterObject && this.$clusterObject.clusters.length > 0) {
       this.$clusterObject.render()
     }
   },


### PR DESCRIPTION
I hit the same problem as https://github.com/NathanAP/vue-google-maps-community-fork/issues/101 . 
```
TypeError: Cannot read properties of undefined (reading 'range')
    at Supercluster.getClusters (index.js?v=5ff1232d:105:26)
    at SuperClusterAlgorithm.cluster (supercluster.ts:92:8)
    at SuperClusterAlgorithm.calculate (supercluster.ts:84:28)
    at MarkerClusterer.render (markerclusterer.ts:175:52)
    at MarkerClusterer.addMarker (markerclusterer.ts:110:12)
    at marker.vue:128:12
```
I believe it's a race condition, and `render` is being called before the `clusters` array has been populated.